### PR TITLE
fixed CI-CD pipline checking out from main repo instead of master

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -87,7 +87,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: garygrossgarten/github-action-ssh@v0.6.4
         with:
-          command: cd apiGive && git checkout master && git pull &&  docker-compose -f docker-compose-production.yml pull && docker-compose -f docker-compose-production.yml down && docker-compose -f docker-compose-production.yml up -d && docker image prune -a --force;
+          command: cd apiGive && git checkout main && git pull &&  docker-compose -f docker-compose-production.yml pull && docker-compose -f docker-compose-production.yml down && docker-compose -f docker-compose-production.yml up -d && docker image prune -a --force;
           host: ${{ secrets.PRODUCTION_HOST }}
           username: ${{ secrets.PRODUCTION_USERNAME }}
           privateKey: ${{ secrets.PRODUCTION_PRIVATE_KEY}}


### PR DESCRIPTION
I think there was a problem checking out from "master" branch, I've tested it locally and changed it to "main"
I think it should work now